### PR TITLE
Resolve "Root entity properties for cutoff should be specified as a separate schema in ClinicalTextConfig and include fields for specifying lower and upper cutoff property"

### DIFF
--- a/doc/rest-spec/v1/ehr-explorer-openapi.yaml
+++ b/doc/rest-spec/v1/ehr-explorer-openapi.yaml
@@ -429,12 +429,18 @@ components:
           items:
             type: string
         rootEntityDatetimePropertyForCutoff:
-          type: string
-          example: 'outTime'
+          $ref: '#/components/schemas/RootEntityDatetimePropertyForCutoffSpec'
         rootEntitiesSpec:
           $ref: '#/components/schemas/RootEntitiesSpec'
         clinicalTextExtractionDurationSpec:
           $ref: '#/components/schemas/ClinicalTextExtractionDurationSpec'
+    RootEntityDatetimePropertyForCutoffSpec:
+      type: object
+      properties:
+        propertyForUpperLimit:
+          type: string
+        propertyForLowerLimit:
+          type: string
     ClinicalTextExtractionDurationSpec:
       type: object
       required:


### PR DESCRIPTION
Closes #40