### PR TITLE
Resolve "Root entity properties for cutoff should be specified as a separate schema in ClinicalTextConfig and include fields for specifying lower and upper cutoff property" — fix naming of property

### DIFF
--- a/doc/rest-spec/v1/ehr-explorer-openapi.yaml
+++ b/doc/rest-spec/v1/ehr-explorer-openapi.yaml
@@ -428,7 +428,7 @@ components:
           type: array
           items:
             type: string
-        rootEntityDatetimePropertyForCutoff:
+        rootEntityDatetimePropertyForCutoffSpec:
           $ref: '#/components/schemas/RootEntityDatetimePropertyForCutoffSpec'
         rootEntitiesSpec:
           $ref: '#/components/schemas/RootEntitiesSpec'


### PR DESCRIPTION
Closes #40